### PR TITLE
Move template code body to header file.

### DIFF
--- a/include/LeafBlockLoader.h
+++ b/include/LeafBlockLoader.h
@@ -127,7 +127,23 @@ namespace BCMFileIO {
 		/// @return 成功した場合true, 失敗した場合false
 		///
 		template<typename T>
-		static bool CopyBufferToScalar3D(BlockManager& blockManager, const int dataClassID, const int blockID, const int vc, const T*  buf);
+		static bool CopyBufferToScalar3D(BlockManager& blockManager, const int dataClassID, const int blockID, const int vc, const T*  buf)
+		{       
+			Vec3i size = blockManager.getSize();
+							
+			BlockBase* block = blockManager.getBlock(blockID);
+			Scalar3D<T>* mesh = dynamic_cast< Scalar3D<T>* >(block->getDataClass(dataClassID));
+			T* data      = mesh->getData();         
+			Index3DS idx = mesh->getIndex();                
+											
+			for(int z = -vc; z < size.z + vc; z++){                 
+				for(int y = -vc; y < size.y + vc; y++){                             
+					for(int x = -vc; x < size.x + vc; x++){                                             
+						size_t loc = ( (x+vc) + ((y+vc) + (z+vc) * (size.y + (vc*2))) * (size.x + (vc*2)) );
+						data[idx(x, y, z)] = buf[loc];                                                                          
+					}
+				}                                                                                                                               }   
+			return true;                                                                                                                    }  
 
 	private:
 		/// BitVoxelサイズを取得する

--- a/src/BCMFileLoader.cpp
+++ b/src/BCMFileLoader.cpp
@@ -782,7 +782,7 @@ namespace BCMFileIO {
 						}
 					}
 					// ブロックマネージャ配下のブロックに値をコピー
-					LeafBlockLoader::CopyBufferToScalar3D(m_blockManager, dataClassID[0], did, vc, block);
+					LeafBlockLoader::CopyBufferToScalar3D(m_blockManager, dataClassID[0], did, vc, static_cast<const unsigned char*>(block));
 					did++;
 					delete [] block;
 				}

--- a/src/LeafBlockLoader.cpp
+++ b/src/LeafBlockLoader.cpp
@@ -524,26 +524,5 @@ namespace BCMFileIO {
 		return true;
 	}
 
-	template<typename T>
-	bool LeafBlockLoader::CopyBufferToScalar3D(BlockManager& blockManager, const int dataClassID, const int blockID, const int vc, const T*  buf)
-	{
-		Vec3i size = blockManager.getSize();
-
-		BlockBase* block = blockManager.getBlock(blockID);
-		Scalar3D<T>* mesh = dynamic_cast< Scalar3D<T>* >(block->getDataClass(dataClassID));
-		T* data      = mesh->getData();
-		Index3DS idx = mesh->getIndex();
-
-		for(int z = -vc; z < size.z + vc; z++){
-			for(int y = -vc; y < size.y + vc; y++){
-				for(int x = -vc; x < size.x + vc; x++){
-					size_t loc = ( (x+vc) + ((y+vc) + (z+vc) * (size.y + (vc*2))) * (size.x + (vc*2)) );
-					data[idx(x, y, z)] = buf[loc];
-				}
-			}
-		}
-		return true;
-	}
-
 } // BCMFileIO
 


### PR DESCRIPTION
Template code body must be defined in .h, otherwise such a template function symbol is not visible when using HDMlib from external program, causing an compilation error like this:

```
HDMlib/src/BCMFileLoader.cpp:785: undefined reference to `bool BCMFileIO::LeafBlockLoader::CopyBufferToScalar3D<unsigned char>(BlockManager&, int, int, int, unsigned char const*)'
```
